### PR TITLE
Add the handling of DERIVE/ABSOLUTE/COUNTER types

### DIFF
--- a/ZenPacks/zenoss/Import4/rrd2tsdb.py
+++ b/ZenPacks/zenoss/Import4/rrd2tsdb.py
@@ -118,8 +118,8 @@ class ImportRRD():
         if self.type == 'GAUGE':
             _value = float(content.strip())
         elif self.type == 'DERIVE' or self.type == 'COUNTER':
-            self.derived_value += float(content.strip()) * self.step
-            _value = self.derived_value
+            self.derived_value += float(content.strip())
+            _value = self.derived_value * self.step
         elif self.type == 'ABSOLUTE':
             _value = float(content.strip())*self.step
         else:

--- a/ZenPacks/zenoss/Import4/rrd2tsdb.py
+++ b/ZenPacks/zenoss/Import4/rrd2tsdb.py
@@ -62,7 +62,8 @@ class ImportRRD():
             raise _Error('E_DMD')
 
         log.debug(rrdPath)
-        _f_name = rrdPath.lstrip(perfPath)
+        if rrdPath.startswith(perfPath):
+            _f_name = rrdPath[len(perfPath):]
         if _f_name[0] == '/':
             _f_name = _f_name[1:]
 

--- a/ZenPacks/zenoss/Import4/rrd2tsdb.py
+++ b/ZenPacks/zenoss/Import4/rrd2tsdb.py
@@ -136,8 +136,8 @@ class ImportRRD():
             self.type = content.strip()
             log.info("Type:%s" % self.type)
             # if a DERIVE or COUNTER type check accompanying _GAUGE file
-            # if so, skip the traversing altogether if self.type == 'DERIVE' or self.type == 'COUNTER':
-            if self.type == 'DERIVE':
+            # if so, skip the traversing altogether
+            if self.type == 'DERIVE' or self.type == 'COUNTER':
                 _gFile = self.rrdPath[:-4] + "_GAUGE.rrd"
                 if os.path.isfile(_gFile):
                     log.info("Found GAUGE file, skipping %s" % self.rrdPath)

--- a/ZenPacks/zenoss/Import4/rrd2tsdb.py
+++ b/ZenPacks/zenoss/Import4/rrd2tsdb.py
@@ -154,13 +154,12 @@ class ImportRRD():
         elif tag == 'v':
             self._process_v(tag_path, content)
         elif tag == 'cf':
+            # note that multiple AVERAGE section
+            # may produce out-of-order and dup value
+            # results need to be post processed by sort | uniq
+            # before feeding to tsdb import
             log.info("cf.%s" % content)
-            # if cf is already AVERAGE, no need to process another cf section
-            if self.cf == 'AVERAGE':
-                raise _Error('E_STOP')
-            else:
-                self.cf = content.strip()
-
+            self.cf = content.strip()
         elif tag == 'step':
             self.step = float(content.strip())
             if self.step <= 0.0:

--- a/ZenPacks/zenoss/Import4/rrd2tsdb.py
+++ b/ZenPacks/zenoss/Import4/rrd2tsdb.py
@@ -19,6 +19,7 @@ import re
 import os.path
 
 log = logging.getLogger(__name__)
+script_path = os.path.dirname(os.path.realpath(__file__))
 
 _ES = OrderedDict(
     E_ID='RRD path does not contain a device ID',
@@ -58,8 +59,9 @@ class ImportRRD():
         # LINUX time regex
         self.tm_re = re.compile('\d{8,15}')
         try:
-            self.dmd_uuid = subprocess.check_output("./bin/get_dmduuid.sh",
-                                                    shell=True)
+            self.dmd_uuid = subprocess.check_output(
+                script_path + "/bin/get_dmduuid.sh",
+                shell=True)
         except:
             raise _Error('E_DMD')
 


### PR DESCRIPTION
1. If a _GAUGE rrdfile is found accompanying the DERIVE type, use it
2. treat COUNTER the same as DERIVE
3. treat ABSOLUTE similar to GAUGE
4. use format {.10e} for float to string representation