### PR TITLE
Prevalidation of perf data

### DIFF
--- a/ZenPacks/zenoss/Import4/bin/import4
+++ b/ZenPacks/zenoss/Import4/bin/import4
@@ -9,9 +9,10 @@
 ##############################################################################
 
 import argparse
-import sys
+import sys, traceback
 
 from ZenPacks.zenoss.Import4 import migration, model, events, perf
+from ZenPacks.zenoss.Import4.migration import Config
 
 exitCode = {
     # event module mapping
@@ -58,7 +59,8 @@ def run_migration(migration_class, args):
             # else, we continue
     except Exception as e:
         # unrecognized exception
-        print "Huh? unknown exception", e
+        print "Huh? unknown exception during import ---", e
+        traceback.print_exc(file=sys.stderr)
         exit(-1)
 
     # all finished successfully
@@ -86,7 +88,7 @@ def parse_args():
                         help="Continue with the import even if pre-validation generates warnings")
     parser.add_argument('-d', '--debug', action='store_true', dest='debug', default=False,
                         help="Log at debug level")
-    parser.add_argument('-s', '--stage', dest='staging_dir', default='.',
+    parser.add_argument('-s', '--stage', dest='staging_dir', default=Config.stageDir,
                         help="Location to use for file staging during the import process")
     parser.add_argument('-i', '--ip', dest='ip', default="localhost",
                         help="The ip address for MariaDB host")

--- a/ZenPacks/zenoss/Import4/migration.py
+++ b/ZenPacks/zenoss/Import4/migration.py
@@ -13,6 +13,23 @@ class Results(object):
     WARNING = 'WARNING'
     FAILURE = 'FAILURE'
 
+
+class Config(object):
+    volume =        '/import4'
+    pkgPath =       '/import4/pkg'
+    pkgBinPath =    '/import4/pkg/bin'
+    stageDir =      '/import4/staging'
+    zenbackupDir =  '/import4/staging/zenbackup'
+    perfDir =       '/import4/staging/zenbackup/perf'
+    rrdTop =        '/import4/staging/zenbackup/perf/Devices'
+    # content of a 4.x zenbackup file
+    zepBackup =     'zenbackup/zep.sql.gz'
+    zepSQL =        'zenbackup/zep.sql'
+    zenpackBackup = 'zenbackup/ZenPacks.tar'
+    perfBackup =    'zenbackup/perf.tar'
+    zodbBackup =    'zenbackup/zodb.sql.gz'
+
+
 import inspect
 
 

--- a/ZenPacks/zenoss/Import4/perf.py
+++ b/ZenPacks/zenoss/Import4/perf.py
@@ -59,6 +59,8 @@ def init_command_parser(subparsers):
                              help="Top directory for a existing 4.x rrd tree")
     perf_parser.add_argument('-t', '--perf_top', dest='perf_top', default="",
                              help="Parent directory of the rrd trees")
+    perf_parser.add_argument('-n', '--skip-scan', action='store_true', dest='skip_scan', default=False,
+                        help="Skip the scanning of rrdfiles' content")
     return perf_parser
 
 
@@ -70,6 +72,7 @@ class Migration(MigrationBase):
         # check and install the scripts for mariadb and opentsdb services
         self.rrd_dir_arg = args.rrd_dir
         self.rrd_dir = os.path.abspath(args.rrd_dir)
+        self.skip_scan = args.skip_scan
 
         # if self.perf_top does not exist, derive it from rrd_dir
         if args.perf_top:
@@ -136,6 +139,10 @@ class Migration(MigrationBase):
             print e
             raise PerfDataImportError(Results.INVALID, -1)
         self.reportProgress("rrd's to scan:%s" % _files_no)
+
+        if self.skip_scan:
+            self.reportProgress("rrd scanning skip option specified - skipped")
+            return
 
         # we go thru each rrdfile and do a dryrun
         self.reportProgress("Scanning rrdfiles ...")

--- a/ZenPacks/zenoss/Import4/perf.py
+++ b/ZenPacks/zenoss/Import4/perf.py
@@ -127,12 +127,10 @@ class Migration(MigrationBase):
         try:
             _rrd_list = '%s/rrd.list' % Config.perfDir
             _cmd = 'find %s -type f -name "*.rrd"' % self.rrd_dir
-            _rlfile = open(_rrd_list, "w")
-            _errfile = open('%s.err' % _rrd_list, "w")
-            subprocess.check_call(_cmd, shell=True,
-                                  stdout=_rlfile, stderr=_errfile)
-            _rlfile.close()
-            _errfile.close()
+
+            with open(_rrd_list, "w") as _rlfile, open('%s.err' % _rrd_list, "w") as _errfile:
+                subprocess.check_call(_cmd, shell=True, stdout=_rlfile, stderr=_errfile)
+
             _cmd = 'cat %s | wc -l' % _rrd_list
             _files_no = int(subprocess.check_output('cat %s | wc -l' % _rrd_list, shell=True))
         except Exception as e:
@@ -261,13 +259,13 @@ class Migration(MigrationBase):
             raise PerfDataImportError(Results.COMMAND_ERROR, _rc)
 
         # untar the zenbackup file for perf.tar file
-        _cmd = 'tar --totals -R --wildcards-match-slash -C %s -f %s -x %s' % (
+        _cmd = 'tar -v --totals -R --wildcards-match-slash -C %s -f %s -x %s' % (
             Config.stageDir, self.file.name, Config.perfBackup)
         _rc = os.system(_cmd)
         if _rc > 0:
             raise PerfDataImportError(Results.COMMAND_ERROR, _rc)
 
-        _cmd = 'tar --totals -R -C %s -xf %s/%s' % (
+        _cmd = 'tar -v --totals -R -C %s -xf %s/%s' % (
             Config.zenbackupDir, Config.stageDir, Config.perfBackup)
         _rc = os.system(_cmd)
         if _rc > 0:

--- a/ZenPacks/zenoss/Import4/perf.py
+++ b/ZenPacks/zenoss/Import4/perf.py
@@ -7,22 +7,23 @@
 #
 ##############################################################################
 
+import argparse
 import os
 import sys
 import subprocess
 import re
 import time
 
-from ZenPacks.zenoss.Import4.migration import MigrationBase, ImportError
+from ZenPacks.zenoss.Import4.migration import MigrationBase, ImportError, Config
 
 # some common constants shared among the py and bash scripts
 _check_tag = '[Check] '
 _stderr_tag = '[STDERR] '
 _import_prefix = 'Perf: '
 
-_import4_vol = '/import4'
-_import4_pkg = '/import4/pkg'
-_import4_pkg_bin = '/import4/pkg/bin'
+_import4_vol = Config.volume
+_import4_pkg = Config.pkgPath
+_import4_pkg_bin = Config.pkgBinPath
 
 _tasks_Q = '%s/Q.tasks' % _import4_vol
 _jobs_Q = '%s/Q.jobs' % _import4_vol
@@ -50,8 +51,12 @@ class PerfDataImportError(ImportError):
 def init_command_parser(subparsers):
     perf_parser = subparsers.add_parser('perf', help='migrate performance data')
     # TBD collect the rrd top and perf data top
-    perf_parser.add_argument('rrd_dir',
-                             help="Top directory for a 4.x rrd tree")
+    perf_parser.add_argument('file', type=argparse.FileType('r'),
+                             help="4.x archive file to import")
+    # if rrd_dir is specified, it will only import the selected
+    # and already existing rrd sub_dir, zenbackup file is checked and ignored
+    perf_parser.add_argument('-r', '--rrd_dir', dest='rrd_dir', default="",
+                             help="Top directory for a existing 4.x rrd tree")
     perf_parser.add_argument('-t', '--perf_top', dest='perf_top', default="",
                              help="Parent directory of the rrd trees")
     return perf_parser
@@ -63,10 +68,19 @@ class Migration(MigrationBase):
         super(Migration, self).__init__(args, progressCallback)
 
         # check and install the scripts for mariadb and opentsdb services
+        self.rrd_dir_arg = args.rrd_dir
         self.rrd_dir = os.path.abspath(args.rrd_dir)
-        self.perf_top = os.path.abspath(args.perf_top)
+
+        # if self.perf_top does not exist, derive it from rrd_dir
+        if args.perf_top:
+            self.perf_top = os.pat.abspath(args.perf_top)
+        else:
+            _idx = self.rrd_dir.find("Devices/")
+            self.perf_top = self.rrd_dir[:_idx+7]
+
+        self.file = args.file
         if not os.path.exists(_import4_vol):
-            print _import_prefix + "%s does not exist" % _import4_vol
+            self.reportProgress("%s does not exist" % _import4_vol)
             raise PerfDataImportError(Results.RUNTIME_ERROR, -1)
 
         # always copy the small pkg for the imp4mariadb and imp4opentsdb services
@@ -83,11 +97,78 @@ class Migration(MigrationBase):
             raise PerfDataImportError(Results.RUNTIME_ERROR, _rc)
 
     def prevalidate(self):
+        # due to the lengthy single process validation
+        # we will do the prevalidation only in check mode
+        # further, the user has to do a checkrun always
+        # this unpacks the perf data into rrdtree
+        if not self.args.dryrun:
+            self.reportProgress("Non-dryrun mode, prevalidation and unpacking process skipped...")
+            return
+
+        # check if tarball is ok by untar it to the /import4
+        # only untar when a target rrd_dir is not specified
+        if not self.rrd_dir_arg:
+            self._untarZenbackup()
+            self.rrd_dir = '%s/Devices' % Config.perfDir
+            self.perf_top = self.rrd_dir
+        else:
+            self.reportProgress("%s provided. unpacking process skipped..." % self.rrd_dir)
+
+        # else, rrd_dir is the one derived from provided rrd_dir_arg
         # check if the rrd_dir is valid
         if not os.path.exists(self.rrd_dir):
-            print _import_prefix + "%s does not exist" % self.rrd_dir
+            self.reportProgress("%s does not exist" % self.rrd_dir)
             raise PerfDataImportError(Results.INVALID, -1)
-        # TBD:what other easy checks can we do??
+
+        # here we do a single-process check of the rrdfiles
+        try:
+            _rrd_list = '%s/rrd.list' % Config.perfDir
+            _cmd = 'find %s -type f -name "*.rrd"' % self.rrd_dir
+            _rlfile = open(_rrd_list, "w")
+            _errfile = open('%s.err' % _rrd_list, "w")
+            subprocess.check_call(_cmd, shell=True,
+                                  stdout=_rlfile, stderr=_errfile)
+            _rlfile.close()
+            _errfile.close()
+            _cmd = 'cat %s | wc -l' % _rrd_list
+            _files_no = int(subprocess.check_output('cat %s | wc -l' % _rrd_list, shell=True))
+        except Exception as e:
+            print e
+            raise PerfDataImportError(Results.INVALID, -1)
+        self.reportProgress("rrd's to scan:%s" % _files_no)
+
+        # we go thru each rrdfile and do a dryrun
+        self.reportProgress("Scanning rrdfiles ...")
+        _total_dr = 0
+        _total_dp = 0
+        _total_ds = 0
+        try:
+            with open(_rrd_list, "r") as f:
+                for _aline in f:
+                    _one_rrd = _aline.strip()
+                    self.reportProgress("%s ..." % _one_rrd)
+                    _cmd = '%s/rrd2tsdb.py -t -p "%s" "%s"' % (Config.pkgPath, self.perf_top, _one_rrd)
+                    _result = subprocess.check_output(_cmd, shell=True, stderr=None).strip()
+                    self.reportProgress("%s datapoints..." % _result)
+                    _total_dp += int(_result)
+                    if int(_result):
+                        _total_ds += 1
+                    else:
+                        # check if the 0 results from a dup derived in rrd file
+                        # remove .rrd
+                        if os.path.isfile("%s_GAUGE.rrd" % _one_rrd[:-4]):
+                            self.reportProgress("Info: DERIVE type dup'ed into GAUGE")
+                            _total_dr += 1
+                        else:
+                            self.reportProgress("Warn: no datapoint found")
+        except Exception as e:
+            print e
+            raise PerfDataImportError(Results.INVALID, -1)
+
+        self.reportProgress("DS#: %d" % _total_ds)
+        self.reportProgress("DR#: %d" % _total_dr)
+        self.reportProgress("DP#: %d" % _total_dp)
+        return
 
     def postvalidate(self):
         self.__NOT_YET__()
@@ -95,9 +176,9 @@ class Migration(MigrationBase):
         return
 
     def wipe(self):
-        self.__NOT_YET__()
-        # need to place a command tag for imp4opentsdb service
-        # to clean up the backend
+        # self.__NOT_YET__()
+        # it is decided that we don't wipe the pre-existing opentsdb
+        # This allows incremental importing of selected devices
         return
 
     def doImport(self):
@@ -158,4 +239,31 @@ class Migration(MigrationBase):
         if _msg:
             _msg = _import_prefix + '%s\n' % _msg.strip()
             super(Migration, self).reportProgress(_msg)
+        return
+
+    def _untarZenbackup(self):
+        # unpack the backup page to perf.tar
+        # remove the target dir
+        if not os.path.exists(Config.stageDir):
+            os.makedirs(Config.stageDir)
+
+        # clean up
+        _cmd = 'rm -rf %s' % Config.perfDir
+        _rc = os.system(_cmd)
+        if _rc > 0:
+            raise PerfDataImportError(Results.COMMAND_ERROR, _rc)
+
+        # untar the zenbackup file for perf.tar file
+        _cmd = 'tar --totals -R --wildcards-match-slash -C %s -f %s -x %s' % (
+            Config.stageDir, self.file.name, Config.perfBackup)
+        _rc = os.system(_cmd)
+        if _rc > 0:
+            raise PerfDataImportError(Results.COMMAND_ERROR, _rc)
+
+        _cmd = 'tar --totals -R -C %s -xf %s/%s' % (
+            Config.zenbackupDir, Config.stageDir, Config.perfBackup)
+        _rc = os.system(_cmd)
+        if _rc > 0:
+            raise PerfDataImportError(Results.COMMAND_ERROR, _rc)
+
         return


### PR DESCRIPTION
bin/import4:
- unify the input zenbackup file in argument line
- using global config data

migration.py
- provide global config data

events.py:
- using the global config data

perf.py:
- using the global config data
- derive the perf top from the rrd path if not specified
- prevalidation steps, uncompress, untar, check rrd files
- ?? Object check to be delayed until model/obj imported
- no wipe

rrd2tsdb.py:
- add test mode for prevalidation