### PR TITLE
Add the upgrade zep schema + migrate staging enforcement

### DIFF
--- a/ZenPacks/zenoss/Import4/bin/import4
+++ b/ZenPacks/zenoss/Import4/bin/import4
@@ -16,6 +16,15 @@ from ZenPacks.zenoss.Import4 import migration, model, events, perf
 from ZenPacks.zenoss.Import4.migration import Config
 
 exitCode = {
+    # perf module mapping
+    perf.Results.COMMAND_ERROR: 11,
+    perf.Results.UNTAR_FAIL: 10,
+    perf.Results.INVALID: 9,
+
+    perf.Results.FAILURE: 2,
+    perf.Results.WARNING: 1,
+    perf.Results.SUCCESS: 0,
+
     # event module mapping
     events.Results.COMMAND_ERROR: 8,
     events.Results.UNTAR_FAIL: 7,
@@ -63,6 +72,8 @@ def run_migration(migration_class, args):
         elif (_rc == exitCode[migration.Results.WARNING]) and (not args.ignorewarnings):
             exit(_rc)
             # else, we continue
+        else:
+            exit(_rc)
     except Exception as e:
         # unrecognized exception
         print "Huh? unknown exception during import ---", e

--- a/ZenPacks/zenoss/Import4/migration.py
+++ b/ZenPacks/zenoss/Import4/migration.py
@@ -46,7 +46,10 @@ class MigrationBase(object):
         self.tempDir = args.staging_dir
         self.ip = args.ip
         self.user = args.user
-        self.password = args.password
+        if args.password:
+            self.password = args.password
+        else:
+            self.password = ''
         self.zbfile = args.zenbackup_file
 
     def __NOT_YET__(self):

--- a/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
+++ b/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
@@ -150,7 +150,7 @@
        "Prereqs": [
          {
            "Name": "MariaDB Availability",
-           "Script": "mysql -uroot -hlocalhost -P3306 -e 'select 1' > /dev/null"
+           "Script": "su - zenoss -c '/opt/zenoss/bin/python /opt/zenoss/Products/ZenUtils/ZenDB.py --usedb zodb --execsql=\";\"'"
          }
        ],
        "MonitoringProfile": {


### PR DESCRIPTION
1. Add the upgrade zep schema after the event data is imported
2. Force the user to run prevalidation (-c option) at least
   once for both event and perf data migration
3. Force the user to migrate successful first (-x option) before
   they can run the postvalidate process
4. Fix the credential parameter passed to rrd2tsdb / curl