### PR TITLE
model import skeleton + container def changes

### DIFF
--- a/ZenPacks/zenoss/Import4/bin/install_pkg.sh
+++ b/ZenPacks/zenoss/Import4/bin/install_pkg.sh
@@ -18,11 +18,13 @@ echo "Installing import4 worker scripts from $progdir ..."
 mkdir -p "$BIN_D"     || err_exit "Cannot create the pkg directories"
 
 # copy the scripts
-cp "$progdir"/../*.py "$PKG_D"  || err_exit "Error copying python scripts"
-cp "$progdir"/*.sh "$BIN_D"     || err_exit "Error copying bash scripts"
+chmod +x "$progdir"/../*.py         || err_exit "Error chmod python scripts"
+cp -p "$progdir"/../*.py "$PKG_D"   || err_exit "Error copying python scripts"
+chmod +x "$progdir"/*.sh            || err_exit "Error chmod bash scripts"
+cp -p "$progdir"/*.sh "$BIN_D"      || err_exit "Error copying bash scripts"
 
 # now move the worker scripts so the services can start
-mv "$BIN_D/src_imp4mariadb.sh"   "$BIN_D/imp4mariadb.sh"  || err_exit "Error copying perfdata converter worker script"
+mv "$BIN_D/src_imp4mariadb.sh"    "$BIN_D/imp4mariadb.sh"   || err_exit "Error copying perfdata converter worker script"
 mv "$BIN_D/src_imp4opentsdb.sh"   "$BIN_D/imp4opentsdb.sh"  || err_exit "Error copying opentsdb import worker script"
 sync
 

--- a/ZenPacks/zenoss/Import4/model.py
+++ b/ZenPacks/zenoss/Import4/model.py
@@ -7,9 +7,25 @@
 #
 ##############################################################################
 
-import argparse
-from migration import MigrationBase
+'''
+Import the models backed up in the zenbackup tarball
+'''
 
+from ZenPacks.zenoss.Import4.migration import MigrationBase, ImportError, Config
+
+
+class Results(object):
+    COMMAND_ERROR = 'MODELMIGRATION_COMMAND_ERROR'
+    UNTAR_FAIL = 'MODELMIGRATION_UNTAR_FAILED'
+    INVALID = 'MODELMIGRATION_INVALID'
+    WARNING = 'MODELMIGRATION_WARNING'
+    FAILURE = 'MODELMIGRATION_FAILURE'
+    SUCCESS = 'MODELMIGRATION_SUCCESS'
+
+
+class ModelImportError(ImportError):
+    def __init__(self, error_string, return_code):
+        super(ModelImportError, self).__init__(error_string, return_code)
 
 def init_command_parser(subparsers):
     model_parser = subparsers.add_parser('model', help='migrate model data')
@@ -17,4 +33,35 @@ def init_command_parser(subparsers):
 
 
 class Migration(MigrationBase):
-    pass
+    def __init__(self, args, progressCallback):
+        super(Migration, self).__init__(args, progressCallback)
+        # all the args is in self.args
+
+    def prevalidate(self):
+        if not self.zbfile:
+            self.reportProgress('No zenbackup package provided..')
+            raise EventImportError(Results.UNTAR_FAIL, -1)
+
+        self._untarBackup()
+        self._checkFiles()
+        self.reportProgress('Success...')
+        return
+
+    def reportProgress(self, raw_line):
+        super(Migration, self).reportProgress(raw_line)
+
+    def wipe(self):
+        self.__NOT_YET__()
+
+    def doImport(self):
+        self.__NOT_YET__()
+
+    def postvalidate(self):
+        self.__NOT_YET__()
+
+    def _untarBackup(self):
+        pass
+
+    def _checkFiles(self):
+        pass
+

--- a/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
+++ b/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
@@ -22,10 +22,25 @@
         "Context": null,
         "Endpoints": [
          {
-           "Name": "mariadb",
+           "Name": "zep_mariadb",
            "Purpose": "import",
            "Protocol": "tcp",
            "PortNumber": 3306,
+           "PortTemplate": "",
+           "VirtualAddress": "",
+           "Application": "zep_mariadb",
+           "ApplicationTemplate": "",
+           "AddressConfig": {
+             "Port": 0,
+             "Protocol": ""
+           },
+           "VHosts": null
+         },
+         {
+           "Name": "zodb_mariadb",
+           "Purpose": "import",
+           "Protocol": "tcp",
+           "PortNumber": 3307,
            "PortTemplate": "",
            "VirtualAddress": "",
            "Application": "zodb_mariadb",
@@ -80,7 +95,14 @@
          {
            "Owner": "mysql:mysql",
            "Permission": "0755",
-           "ResourcePath": "mariadb",
+           "ResourcePath": "mariadb-model",
+           "ContainerPath": "/var/lib/mysql.model",
+           "Type": ""
+         },
+         {
+           "Owner": "mysql:mysql",
+           "Permission": "0755",
+           "ResourcePath": "mariadb-events",
            "ContainerPath": "/var/lib/mysql",
            "Type": ""
          },
@@ -143,14 +165,14 @@
        "Actions": null,
        "HealthChecks": {
          "running": {
-           "Script": "mysql -uroot -hlocalhost -P3306 -e 'select 1' > /dev/null",
+           "Script": "mysql --socket=/var/lib/mysql/mysql.sock -uroot -hlocalhost -P3306 -e 'select 1' && mysql --socket=/var/lib/mysql.model/mysql.sock -uroot -hlocalhost -P3307 -e 'select 1' > /dev/null",
            "Interval": 5.0
          }
        },
        "Prereqs": [
          {
-           "Name": "MariaDB Availability",
-           "Script": "su - zenoss -c '/opt/zenoss/bin/python /opt/zenoss/Products/ZenUtils/ZenDB.py --usedb zodb --execsql=\";\"'"
+           "Name": "MariaDB zodb and zep Availability",
+           "Script": "su - zenoss -c '/opt/zenoss/bin/python /opt/zenoss/Products/ZenUtils/ZenDB.py --dbport 3306 --usedb zep --execsql=\";\"' && su - zenoss -c '/opt/zenoss/bin/python /opt/zenoss/Products/ZenUtils/ZenDB.py --dbport 3307 --usedb zodb --execsql=\";\"' "
          }
        ],
        "MonitoringProfile": {

--- a/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
+++ b/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
@@ -165,7 +165,7 @@
        "Actions": null,
        "HealthChecks": {
          "running": {
-           "Script": "mysql --socket=/var/lib/mysql/mysql.sock -uroot -hlocalhost -P3306 -e 'select 1' && mysql --socket=/var/lib/mysql.model/mysql.sock -uroot -hlocalhost -P3307 -e 'select 1' > /dev/null",
+           "Script": "mysql --socket=/var/lib/mysql/mysql.sock -uroot -e 'select 1' && mysql --socket=/var/lib/mysql.model/mysql.sock -uroot -e 'select 1' > /dev/null",
            "Interval": 5.0
          }
        },

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
 
     # The MANIFEST.in file is the recommended way of including additional files
     # in your ZenPack. package_data is another.
-    #package_data={}
+    package_data={'scripts': ['bin/*']},
 
     # Indicate dependencies on other python modules or ZenPacks.  This line
     # is modified by zenoss when the ZenPack edit page is submitted.  Zenoss


### PR DESCRIPTION
1. changes in model.py is just a skeleton for the actual model import code.
2. imp4mariadb includes the new mounting points and also the end points
   for the two different mariadb backends, one for events and one for
   models. We retain the events port/socket for events import to
   minimize changes to the other migration scripts
   (i.e. /opt/zenoss/bin/zeneventserver-create-db)