### PR TITLE
Change health check

### DIFF
--- a/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
+++ b/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
@@ -195,7 +195,7 @@
        "Actions": null,
        "HealthChecks": {
          "running": {
-           "Script": "which rrdtool && [ 2 -eq $(ps -ef | grep '/bin/bash /import4/pkg/bin/imp4mariadb.sh' | wc -l) ] > /dev/null",
+           "Script": "which rrdtool && [ 1 -eq $(pgrep -fla '/bin/bash /import4/pkg/bin/imp4mariadb.sh' | wc -l) ] > /dev/null",
            "Interval": 5.0
          }
        },

--- a/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
+++ b/ZenPacks/zenoss/Import4/service_definition/imp4mariadb.json
@@ -195,7 +195,7 @@
        "Actions": null,
        "HealthChecks": {
          "running": {
-           "Script": "which rrdtool && mysql --socket=/var/lib/mysql/mysql.sock -uroot -e 'select 1' && mysql --socket=/var/lib/mysql.model/mysql.sock -uroot -e 'select 1' > /dev/null",
+           "Script": "which rrdtool && [ 2 -eq $(ps -ef | grep '/bin/bash /import4/pkg/bin/imp4mariadb.sh' | wc -l) ] > /dev/null",
            "Interval": 5.0
          }
        },


### PR DESCRIPTION
This service can run on different host from mariadb so the health
check shouldn't rely on such.

Also, the converter service itself does not rely on maraidb.